### PR TITLE
fix(design-system): re-sync living reference with shipped redesign

### DIFF
--- a/src/app/design-system/_components/accessibility-band.tsx
+++ b/src/app/design-system/_components/accessibility-band.tsx
@@ -144,7 +144,7 @@ export function AccessibilityBand() {
                 .
               </td>
               <td className="py-3 px-4 text-meta text-fg-muted">
-                Every arrow, illustration, plasma, and wordmark glyph. The wrapping
+                Every arrow, illustration, and wordmark glyph. The wrapping
                 {' '}
                 <code className="text-accent">&lt;a&gt;</code>
                 {' '}
@@ -158,7 +158,7 @@ export function AccessibilityBand() {
             <tr className="border-b border-rule last:border-b-0">
               <td className="py-3 px-4 text-meta text-fg font-semibold align-top">Reduced-motion handling.</td>
               <td className="py-3 px-4 text-meta text-fg-muted">
-                Global override zeroes animation- and transition-duration. Plasma renders one frame.
+                Global override zeroes animation- and transition-duration. The hero&#x2019;s stipple art renders one static frame.
                 Press-scale rules are individually gated with
                 {' '}
                 <code className="text-accent">@media (prefers-reduced-motion: no-preference)</code>

--- a/src/app/design-system/_components/components-band.tsx
+++ b/src/app/design-system/_components/components-band.tsx
@@ -270,9 +270,9 @@ export function ComponentsBand() {
           <Portrait
             src="/me.jpg"
             alt="Portrait of André Silva — focus or tap to reveal natural color"
-            width={160}
-            height={160}
-            className="max-w-40"
+            width={200}
+            height={260}
+            className="w-50 aspect-[200/260] border border-rule"
           />
         </Demo>
 

--- a/src/app/design-system/_components/cover.tsx
+++ b/src/app/design-system/_components/cover.tsx
@@ -44,7 +44,7 @@ export function Cover() {
         {[
           { label: 'tokens', value: '43' },
           { label: 'components', value: '17' },
-          { label: 'standing rules', value: '16' },
+          { label: 'standing rules', value: '14' },
         ].map((stat, i, arr) => (
           <div
             key={stat.label}

--- a/src/app/design-system/_components/layout-band.tsx
+++ b/src/app/design-system/_components/layout-band.tsx
@@ -6,16 +6,16 @@ const shellRows = [
   { selector: 'px-4 md:px-8 (shell padding)', value: '0 32px → 0 16px at ≤ 768px', notes: '32px desktop / 16px mobile gutter.' },
   { selector: '<section> (py-8 border-b border-rule)', value: 'padding: 32px 0; border-bottom: 1px solid --color-rule', notes: 'Last band drops the rule via last:border-b-0 or :last-of-type.' },
   { selector: '<PageHead>', value: 'padding: 48px 0 20px', notes: 'Generous top to set the page\'s identity; --color-rule bottom border.' },
-  { selector: 'Home hero <section>', value: 'padding: 64px 0 48px (lg:pt-16 lg:pb-12)', notes: '2-col flex row at lg: text left, plasma right; collapses to 1-col below lg.' },
+  { selector: 'Home hero <section>', value: 'padding: 64px 0 48px (lg:pt-16 lg:pb-12)', notes: '2-col flex row at lg: text left, hero art right; collapses to 1-col below lg.' },
 ];
 
 const breakpoints = [
   { width: '< lg (1024px)', what: 'Projects <GridFrame className="lg:grid-cols-3"> collapses 3-col → 2-col.' },
-  { width: '< lg (1024px)', what: 'About bio grid (grid-cols-article) collapses to 1-col; portrait widens.' },
-  { width: '< lg (1024px)', what: 'Home hero flex-row collapses to flex-col; <HeroPlasma> is hidden below lg.' },
+  { width: '< lg (1024px)', what: 'About bio grid (grid-cols-article) collapses to 1-col.' },
+  { width: '< lg (1024px)', what: 'Home hero flex-row collapses to flex-col; <HeroArt> swaps its 296×200 right-column box for a full-width band below the pitch.' },
   {
     width: '< md (768px)',
-    what: 'Shell padding 32px → 16px (px-4). <RoleCard> grid-cols-role collapses to 1-col; date gutter flips to horizontal row with bottom border. Articles grid-cols-article-card collapses to 1-col. Home hero display text drops 56px → smaller.',
+    what: 'Shell padding 32px → 16px (px-4). <RoleCard> grid-cols-role collapses to 1-col; date gutter flips to horizontal row with bottom border. Articles grid-cols-article-card collapses to 1-col.',
   },
   { width: '< md (768px)', what: 'Projects <GridFrame> collapses md:grid-cols-2 → 1-col. About education/facts <GridFrame> collapses md:grid-cols-2 → 1-col.' },
   {

--- a/src/app/design-system/_components/motion-band.tsx
+++ b/src/app/design-system/_components/motion-band.tsx
@@ -44,7 +44,7 @@ const standingRules = [
   },
   {
     rule: 'Respect prefers-reduced-motion.',
-    why: 'Global override zeros animation- and transition-duration to 0.01ms; press-scale rules are additionally gated with motion-safe:. The hero plasma renders one static frame instead of looping.',
+    why: 'Global override zeros animation- and transition-duration to 0.01ms; press-scale rules are additionally gated with motion-safe:. The hero\'s stipple art renders one static frame instead of looping.',
   },
   {
     rule: 'Hover effects are gated by hover: hover.',

--- a/src/app/design-system/_components/principles-band.tsx
+++ b/src/app/design-system/_components/principles-band.tsx
@@ -159,19 +159,17 @@ export function PrinciplesBand() {
             is mathematically derived from --photo-filter.
           </Text>
           <Text variant="body" as="p" className="text-fg-muted max-w-prose-wide m-0 mt-2">
-            Same
+            The base portrait grade is
             {' '}
-            <code className="text-accent">hue-rotate</code>
+            <code className="text-accent">grayscale(1) contrast(0.95) brightness(1.02)</code>
+            ; the soft variant eases contrast to
             {' '}
-            as the base, halved
+            <code className="text-accent">0.9</code>
             {' '}
-            <code className="text-accent">sepia</code>
-            , halved
+            and lifts brightness to
             {' '}
-            <code className="text-accent">saturate</code>
-            . When the base filter is re-tuned, the soft variant must be re-derived in parallel.
-            About is the only consumer (touch devices, where the hover reveal is unreachable); the token is
-            mirrored across all 5
+            <code className="text-accent">1.04</code>
+            . Touch devices are its only consumer &mdash; the hover/focus reveal that returns the photo to natural color is unreachable there, and the duotone tint plus scanline overlay never lift, so the photo needs a gentler grade to stay legible underneath them. When the base filter is re-tuned, the soft variant must be re-derived in parallel. The token is mirrored across all 5
             {' '}
             <code className="text-accent">:root</code>
             {' '}

--- a/src/app/design-system/_components/spacing-band.tsx
+++ b/src/app/design-system/_components/spacing-band.tsx
@@ -22,9 +22,14 @@ const proseWidths = [
     label: 'Hero pitch, education descriptions — tight column for short bursts.',
   },
   {
+    token: 'max-w-prose-bio',
+    value: '60ch',
+    label: 'The About page bio paragraph — a mid-width column for the longest sustained prose on the site.',
+  },
+  {
     token: 'max-w-prose-wide',
     value: '68ch',
-    label: 'Body prose — bio, role bullets, article descriptions, chip strips.',
+    label: 'Body prose — role bullets, article descriptions, section intros, chip strips.',
   },
   {
     token: 'max-w-prose-card',
@@ -40,7 +45,7 @@ const componentSizing = [
     consumer: 'Vertical padding on <Tag> chips',
   },
   {
-    token: 'min-w-22 (badge clearance)',
+    token: 'pr-22 (badge clearance)',
     value: '~88px',
     consumer: 'padding-right on featured <ProjectCard> title so the FEATURED badge in the top-right corner clears the title text.',
   },
@@ -107,6 +112,7 @@ export function SpacingBand() {
                 {' '}
                 (8px) because they are the closer-related pair;
                 meta → title uses
+                {' '}
                 <code className="text-accent">mt-3</code>
                 {' '}
                 (12px). The rhythm is
@@ -121,6 +127,7 @@ export function SpacingBand() {
                 <code className="text-accent">&lt;section&gt;</code>
                 {' '}
                 uses
+                {' '}
                 <code className="text-accent">py-8</code>
                 {' '}
                 (32px) plus a 1px rule; inside the band, content groups use
@@ -158,7 +165,7 @@ export function SpacingBand() {
 
       <Text variant="h3" as="h3" className="mt-8 mb-3 text-fg">Prose widths</Text>
       <Text variant="body" className="text-fg-muted max-w-prose-wide mt-2">
-        Three character-based widths cap the readable column without imposing a pixel measurement
+        Four character-based widths cap the readable column without imposing a pixel measurement
         that breaks under user font-size overrides.
       </Text>
       <div className="mt-4 border border-rule p-4 flex flex-col gap-3">

--- a/src/app/design-system/_components/typography-band.tsx
+++ b/src/app/design-system/_components/typography-band.tsx
@@ -55,7 +55,7 @@ const typeScale = [
     token: 'text-micro',
     size: '11px · mono 600 · lh 1.50',
     sampleClass: 'text-micro font-mono font-semibold text-accent uppercase tracking-eyebrow',
-    sample: '// 02 / what i’m doing now',
+    sample: '// 01 / current focus',
   },
 ];
 


### PR DESCRIPTION
## Summary

The `/design-system` route is a living reference doc, but it had drifted out of sync with the shipped redesign. This is a validation pass — every change is a factual correction verified against shipped code, no redesign.

## Corrections

- **Portrait demo** — was a square, borderless 160×160 photo; now the bordered 200×260 portrait, verbatim from the About page (the band claims markup is "verbatim from the five page files").
- **Principle 08** — documented a `--photo-filter-soft` derivation (`hue-rotate`/`sepia`/`saturate`) that no longer exists; rewritten to the shipped `grayscale(1) contrast(0.95) brightness(1.02)` grade and the real touch-device rationale.
- **Stale `<HeroPlasma>` / "plasma"** — the hero is now `<HeroArt>` stipple art, shown at every breakpoint (not "hidden below lg"). Fixed in layout, motion, and accessibility bands.
- **Spacing band** — added the missing `max-w-prose-bio` (60ch) token; corrected the `prose-wide` label; `min-w-22` → `pr-22`; "Three" → "Four" widths; repaired two missing `{' '}` whitespace tokens that rendered "usesmt-3" / "usespy-8".
- **Layout band** — dropped the false "display text drops 56px" and "portrait widens" breakpoint claims.
- **Cover** — "standing rules" stat 16 → 14, matching the Principles band.

## Verification

- `pnpm lint` + `pnpm build` pass; all 9 static pages generate.
- Four-part code review (quality / security / testing / architecture) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)