### PR TITLE
chore: gitignore local agent-pipeline directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ next-env.d.ts
 !.reviews/.gitkeep
 .reports/*
 !.reports/.gitkeep
+.claude/worktrees/
+.claude/scheduled_tasks.lock
+.claire/


### PR DESCRIPTION
## Summary

- Ignore `.claude/worktrees/` — local git worktrees created by `EnterWorktree`, never meant to be tracked.
- Ignore `.claude/scheduled_tasks.lock` — ephemeral scheduler lock, regenerated each session.
- Ignore `.claire/` — parallel session working directory.

`.claude/` stays partly tracked on purpose (agent-memory, agents, hooks, skills, settings.json are committed), so the ignore is path-specific, not a blanket `.claude/` match.

## Test plan

- [x] `git status` in main no longer lists `.claire/`, `.claude/scheduled_tasks.lock`, `.claude/worktrees/` as untracked
- [x] Existing tracked `.claude/` files unaffected (`git ls-files .claude/` still shows 32 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)