### PR TITLE
docs(rules): adopt responsive.md + ui-ux-designer rule additions (toolkit 2026-05-28)

### DIFF
--- a/.claude/agent-rules/ui-ux-designer/rules/components.md
+++ b/.claude/agent-rules/ui-ux-designer/rules/components.md
@@ -58,6 +58,11 @@ This file covers component-level patterns. Motion/typography/color/spacing unive
 **Applies to:** Command palettes, keyboard shortcuts, rapid-fire inputs.
 **Why:** Power users' perceived speed is set by the animation, not the underlying work. Every ms of animation is a tax paid per keystroke.
 
+### Rule: Primary CTAs default to full-width at mobile
+**Numeric baseline:** `width: 100%` for primary (and any secondary sibling) CTAs below 768px.
+**Applies to:** Primary call-to-action buttons on phone-sized viewports.
+**Why:** Full-width matches the tap target to the column and reads as decisive — the modern mobile convention users are trained to expect. An intrinsic-width button left-aligned with empty space to its right reads as a desktop button shrunk down. Exception: editorial / technical / manifesto registers (research instrument, ledger, printed paper) where a consumer-app button would break the typographic discipline — there, keep intrinsic width but group the buttons in a row (`flex-direction: row; gap`) so the leftover space is shared whitespace, not asymmetric drift, and document the choice.
+
 ---
 
 ## Forms + inputs
@@ -272,6 +277,14 @@ This file covers component-level patterns. Motion/typography/color/spacing unive
 
 ---
 
+## Media (images)
+
+### Rule: Photos in fixed-aspect-ratio containers default to `object-fit: cover`
+**Applies to:** An `<img>` inside a fixed-aspect-ratio container — gallery tile, archive card, lookbook frame, masthead photo.
+**Why:** The container's aspect ratio is the page's compositional commitment; the photo should fill it. `object-fit: contain` letterboxes the image inside the card with the card background showing as margins, which reads as "the image didn't load fully," not as deliberate framing. Use `contain` only when the full frame *is* the point (product-on-white, technical illustration, archival scan, UI screenshot), and document the choice. (For serving the right resolution per viewport, see `responsive.md`.)
+
+---
+
 ## Navigation
 
 ### Rule: Breadcrumbs show hierarchical location, not session history — current page is not a link
@@ -286,6 +299,10 @@ This file covers component-level patterns. Motion/typography/color/spacing unive
 **Numeric baseline:** 3–5 tabs.
 **Applies to:** Mobile apps, mobile web.
 **Why:** Bottom tabs are thumb-reachable and always-visible; hamburger hides destinations, hurting discoverability. Serial Position Effect: place the most-used and most-differentiating items at first/last positions.
+
+### Rule: Group the menu trigger (and secondary header items) with a sibling — don't `space-between` everything
+**Applies to:** Three-element headers (brand + menu trigger + CTA) and headers carrying secondary items (version tag, breadcrumbs, eyebrow meta).
+**Why:** `justify-content: space-between` across brand · trigger · CTA pushes the trigger into an empty middle band, reading as a control dropped at a coordinate rather than belonging to anything. Cluster it: left = brand (optionally + trigger), right = CTA (optionally + trigger) — the trigger should read as part of a navigation cluster. `space-between` on every element reads as "I didn't decide how to group these." (For keeping nav reachable and reflowing the header at mobile, see `responsive.md`.)
 
 ### Rule: Keyboard focus must not be obscured by sticky headers/footers
 **Applies to:** All sticky chrome.
@@ -366,3 +383,4 @@ This file covers component-level patterns. Motion/typography/color/spacing unive
 - [Laws of UX — Serial Position Effect](https://lawsofux.com/serial-position-effect/)
 - [Baymard — Dropdown Hover Delay](https://baymard.com/blog/dropdown-menu-flickering-issue)
 - [MDN — font-variant-numeric](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric)
+- [MDN — object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)

--- a/.claude/agent-rules/ui-ux-designer/rules/motion.md
+++ b/.claude/agent-rules/ui-ux-designer/rules/motion.md
@@ -124,6 +124,11 @@ This domain governs perceptual timing (how fast / slow a change should be), easi
 **Applies to:** Modal open with header + body + actions; list reveals; nav menu opens; hero sections.
 **Why:** Simultaneous motion reads as mechanical/scripted; offset timing reads as organic. Stagger also clarifies hierarchy (primary → secondary).
 
+### Rule: Bind stagger delay to entry only — never leak `transition-delay` into hover
+**Numeric baseline:** Apply the stagger offset via `animation-delay` on a keyframe, or scope `transition-delay` to the entry property only, or reset `transition-delay: 0s` on `:hover`/`:focus`. Never put an inline `transition-delay` on an element that also has hover transitions.
+**Applies to:** Staggered card/list grids whose items also have hover transitions.
+**Why:** An inline `transition-delay` (e.g. `style="transition-delay: calc(var(--stagger-base) * 3)"`) applies to *every* transition on the element, including `:hover`. The third card then waits 3×80ms before its hover responds — the experience silently degrades the further down the grid you go, and because each card works in isolation the bug is easy to miss.
+
 ### Rule: Anchor scale/rotate via `transform-origin`
 **Numeric baseline:** Popovers: `transform-origin: var(--radix-popover-content-transform-origin)`. Modals: `transform-origin: center`.
 **Applies to:** Popovers, tooltips, context menus, modal-from-card transitions, expanded cards, dropdown menus.

--- a/.claude/agent-rules/ui-ux-designer/rules/responsive.md
+++ b/.claude/agent-rules/ui-ux-designer/rules/responsive.md
@@ -1,0 +1,174 @@
+# UI Design Rules — Responsive
+
+**Read on-demand when the task involves cross-viewport layout, mobile rendering, fluid type/space, viewport units, container queries, input-modality (touch vs pointer), responsive images, or any check that a UI works across screen sizes.**
+
+This domain governs *responsive correctness*: whether an interface stays legible, operable, and free of overflow across viewport widths and input modalities. It constrains WHAT the page must be capable of, never WHICH aesthetic direction it takes. Sizing geometry, spacing scales, grouping, and touch-target minimums live in `spacing.md`; type sizing and measure live in `typography.md` — this file owns only the cross-viewport / cross-input behavior.
+
+> **Toolkit-managed file — do not edit per-project.** These rules are static and shared across every project using the toolkit. Project-specific design decisions (brand fonts, palette values, chosen breakpoints, component variants) belong in the project's own `design-system.md` and `ui-spec.md` — never here.
+
+---
+
+## Authoring
+
+### Rule: Author mobile-first — unprefixed styles target the smallest viewport
+**Numeric baseline:** Base (unprefixed) CSS for the smallest viewport; layer wider viewports with `min-width` media queries. Never `max-width` queries undoing desktop styles.
+**Applies to:** All CSS architecture and design tokens.
+**Why:** The cascade reads naturally small-to-large; the base case stays the constrained one, so small-screen styles never get accidentally overridden. Desktop-first design-then-squeeze is the failure mode this prevents.
+
+```css
+/* Good — mobile-first */
+.section { padding: 16px; }
+@media (min-width: 768px)  { .section { padding: 32px; } }
+@media (min-width: 1024px) { .section { padding: 48px; } }
+
+/* Bad — desktop-first, undone on mobile */
+.section { padding: 48px; }
+@media (max-width: 768px) { .section { padding: 16px; } }
+```
+
+---
+
+## Viewport coverage
+
+### Rule: Reflow must hold at 320 CSS px; verify at 375 / 414 / 768 / 1024 / 1440
+**Numeric baseline:** Hard floor 320 CSS px (WCAG 1.4.10 Reflow). Visually inspect at 375 (iPhone SE / mini), 414 (Pro Max / Android XL), 768 (tablet portrait), 1024 (small desktop / iPad landscape), 1440 (standard desktop).
+**Applies to:** All layout, before shipping any page.
+**Why:** Low-vision users zoom or use narrow viewports; fixed-width containers exclude them below 320px. The wider set maps to real-world breakpoint failures. Never optimize one width by breaking another — if the design holds at all checkpoints, ship it; if it breaks at one, fix or document the trade-off.
+
+---
+
+## Horizontal overflow
+
+### Rule: Reading body content must never require horizontal scrolling
+**Applies to:** All layout at every checkpoint width.
+**Why:** A page that scrolls sideways to read is broken on mobile. Common offenders: fixed-width grid columns wider than the viewport, images/SVGs with explicit `width` past the container, non-wrapping table content, `nowrap` hero text, code blocks without `overflow-x: auto`. The rules below are the standard fixes.
+
+### Rule: Use `minmax(0, 1fr)` on grid tracks containing images or wide intrinsic content
+**Numeric baseline:** `grid-template-columns: minmax(0, 1fr) ...` (not bare `1fr`) wherever a track may hold an `<img>`, `<picture>`, `<pre>`, or other element with large intrinsic width.
+**Applies to:** CSS Grid track definitions, especially card grids, galleries, code-block layouts.
+**Why:** A bare `1fr` resolves to `minmax(auto, 1fr)`, where the `auto` minimum is the track's largest intrinsic content size. A 1024px-native image inside a `1fr` track forces a 1024px minimum, pushing the grid past viewport on phones. `minmax(0, 1fr)` lets the track shrink below content size.
+
+### Rule: Use `width: 100%`, not `100vw`, for full-bleed widths
+**Applies to:** Full-bleed sections, banners, anything spanning the viewport.
+**Why:** `100vw` includes the scrollbar width on desktop browsers that reserve scrollbar space, causing horizontal overflow equal to the scrollbar (~15px). `width: 100%` with the parent at viewport width is the safe equivalent.
+
+### Rule: Contain intentional overflow with `overflow-x: clip` (not `hidden`) on `html`/`body`
+**Numeric baseline:** `html, body { overflow-x: clip; }`.
+**Applies to:** Root-level horizontal-overflow containment; any element that intentionally overflows its parent (full-bleed sections, oversized headlines, decorative figures past column edges).
+**Why:** `overflow-x: hidden` creates a new scroll container, which breaks `position: sticky` and `position: fixed` on descendants and can trap focus on overflowing inputs. `overflow-x: clip` prevents horizontal scroll without establishing a scroll context, so sticky and fixed positioning keep working. Older Safari requires both `html` and `body`. This contains overflow — it does not fix the cause; find the offending element first.
+
+### Rule: Apply `overflow-wrap: anywhere; min-width: 0` to long-string and display containers
+**Numeric baseline:** `overflow-wrap: anywhere; min-width: 0` on display headings and any container that may hold URLs, code, or long unbroken strings.
+**Applies to:** Hero/display headings, slug/URL displays, inline code in prose, anywhere user-supplied strings render. *(Exception: brand wordmarks at hero size — see `typography.md`; breaking a wordmark mid-word is a layout bug, not an acceptable mitigation.)*
+**Why:** Default `overflow-wrap: normal` only breaks at whitespace and hyphens, so long compounds, uppercase brand names, and URLs overflow narrow viewports. `anywhere` allows mid-word breaks as a last resort. `min-width: 0` is required on flex/grid items, which default to `min-width: auto` (= intrinsic content size) and otherwise prevent the wrap.
+
+---
+
+## Viewport units
+
+### Rule: Use `dvh` / `svh` / `lvh` instead of `vh` for full-height layouts
+**Numeric baseline:** `100dvh` (dynamic), `100svh` (small / URL-bar-visible), `100lvh` (large / URL-bar-hidden). Never `100vh` for layouts that must fit the visible viewport.
+**Applies to:** Full-height heroes, full-screen modals, mobile drawers, anything sized to "one screen".
+**Why:** On mobile browsers `100vh` is computed against the largest viewport (URL bar hidden), so a `100vh` hero extends below the visible area when the bar shows — and doesn't update when the bar retracts. Use `svh` for a guaranteed-fits-on-load size (safe default for heroes), `dvh` for layout that should track chrome changes (use sparingly — it can thrash during scroll if heavy children reflow), `lvh` for immersive full-bleed where occasional overlap is acceptable. Same logic applies to width (`dvw`/`svw`/`lvw`) and logical-axis (`dvb`/`svb`/`dvi`/`svi`) variants.
+
+---
+
+## Type and spacing across viewports
+
+### Rule: Form controls and body text are ≥16px at mobile
+**Numeric baseline:** `font-size: 16px` (`1rem`) minimum on every `<input>`, `<select>`, `<textarea>`, and body-copy element at mobile widths. Floor `--text-base` at `1rem`; the smallest token (`--text-xs`) stays ≥ `0.75rem`/12px and is reserved for decorative kickers / fine print, never load-bearing content.
+**Applies to:** All form controls and body-equivalent text on phone-sized viewports.
+**Why:** iOS Safari zooms the viewport on focus whenever a control's computed `font-size` is under 16px, yanking the layout. 16px is also the comfortable-read floor. Do **not** suppress the zoom with `user-scalable=no` or `maximum-scale=1` in the viewport meta — that breaks pinch-zoom and violates WCAG 1.4.4. Fix the font-size instead.
+
+### Rule: `<pre>` and `<code>` respect the 16px floor at mobile
+**Numeric baseline:** `font-size: var(--text-base)` (the 16px-floor clamp) at mobile; optionally tighten via `clamp()` only at ≥768px where wider line length carries the smaller size.
+**Applies to:** `<pre>` blocks and inline `<code>` — body-text-equivalent content.
+**Why:** The terminal aesthetic tempts a 12–13px mono size to mimic a real terminal, but at mobile that drops below both the iOS auto-zoom threshold and the comfortable-read floor. Terminal feel comes from `--font-mono` + tight tracking + a token background, not from shrinking text below the floor that applies to all body-equivalent content.
+
+### Rule: Scale type and spacing fluidly with `clamp()`
+**Numeric baseline:** `clamp(min, intercept + slopevw·vw, max)` interpolated between a min and max viewport (Utopia method) rather than doubling values at each breakpoint.
+**Applies to:** Type scales and spacing tokens that should breathe at wider sizes without a shape change.
+**Why:** Stepped breakpoints jump; `clamp()` scales continuously, so a value grows smoothly from its mobile floor to its desktop cap. Reserve stepped breakpoints for genuine shape changes (single column → multi-column); use fluid scaling when the design just needs to breathe. The Utopia slope:
+
+```
+slopevw      = ((max − min) / (maxVw − minVw)) × 100
+interceptrem = min − (slopevw × minVw / 100)
+--text-base: clamp(1.125rem, 1.0739rem + 0.2273vw, 1.3125rem);  /* 18px@320 → 21px@1240 */
+```
+
+Inside a container context, `cqi`/`cqw` replace `vw` for type tied to a component's width rather than the page's.
+
+---
+
+## Input modality
+
+### Rule: Distinguish hover from touch with `(hover:)` and `(pointer:)`
+**Applies to:** Any UI whose information or actions depend on hover — dropdowns, submenus, hover-revealed controls, tooltips.
+**Why:** Touch devices cannot hover; a hover-only affordance is invisible to them. Scope hover enhancements behind `(hover: hover) and (pointer: fine)` and provide a tap/focus equivalent (or suppress) under `(hover: none)`. `(pointer: coarse)` (finger input) should enlarge targets to the touch-primary floor in `spacing.md`. These interaction media features are Baseline widely-available.
+
+```css
+.menu-item { /* visible, tappable by default — works for everyone */ }
+
+@media (hover: hover) and (pointer: fine) {
+  .menu-item:hover { background: var(--surface-hover); }
+  .has-submenu:hover > .submenu { display: block; }
+}
+@media (pointer: coarse) {
+  .icon-button { min-block-size: 44px; min-inline-size: 44px; }
+}
+```
+
+### Rule: Touch targets meet the `spacing.md` sizing floor; enlarge on coarse pointers
+**Numeric baseline:** 24×24 CSS px (AA) / 44×44 (touch-primary) per `spacing.md`; treat 44×44 as the practical floor under `(pointer: coarse)`.
+**Applies to:** All pointer targets on touch-capable or mixed-input devices.
+**Why:** The sizing minimums and hit-area techniques live in `spacing.md` (a target's size is viewport-independent). What is *responsive* is detecting coarse input and sizing up accordingly — don't restate the numbers, reference them and branch on `(pointer: coarse)`.
+
+---
+
+## Component-level responsiveness
+
+### Rule: Use container queries for component-level adaptation
+**Numeric baseline:** `container-type: inline-size` on the parent; `@container (min-width: …)` on the child. Baseline since early 2023 across Chrome, Edge, Firefox, Safari.
+**Applies to:** Components reused at multiple widths — cards, sidebars, form groups, embeds in unknown layout slots.
+**Why:** A component should adapt to *its container's* width, not the viewport's, so the same card behaves correctly in a wide main column and a narrow sidebar. Heuristic: **media queries for page-level layout (header collapse, page columns), container queries for component-level layout.** Treating `@container` as "future tech" and nesting media queries instead is now an anti-pattern.
+
+### Rule: Serve responsively-sized images with `srcset` + `sizes`
+**Applies to:** Photos whose display size varies meaningfully across viewports (hero at 100% width on mobile, 50% on desktop).
+**Why:** A single large source wastes mobile bandwidth; `sizes` lets the browser pick the right resolution, and `srcset` supplies the candidates. Add `loading="lazy"` + `decoding="async"` to below-the-fold images; keep the first 1–2 hero images eager.
+
+```html
+<img src="hero-800.jpg"
+     srcset="hero-400.jpg 400w, hero-800.jpg 800w, hero-1600.jpg 1600w"
+     sizes="(min-width: 1024px) 50vw, 100vw" alt="…" />
+```
+
+---
+
+## Navigation
+
+### Rule: Navigation must remain reachable at mobile
+**Applies to:** Any page with a `<nav>`, at 375 and 414 widths.
+**Why:** Nav items must be reachable on phones via one of: (1) still visible — wrap, stack, or scroll horizontally as one row; (2) collapse behind a visible trigger (a "menu" link, a `<details>`/`<summary>` disclosure, a `<button aria-expanded>` hamburger — pick whatever fits the register; hamburger is one option, not a default), the trigger meeting the touch-target floor and the menu opening via CSS-only or honest JS; (3) mirror as in-page anchor links elsewhere (a section directory in the hero or footer). Silently hiding nav with `display: none` and no fallback is unreachable navigation — never ship it.
+
+### Rule: Mobile nav reflow is all-or-nothing — whole nav drops, never stranded items
+**Numeric baseline:** Header at mobile uses `flex-direction: column` (brand row, then full nav row) or a `grid` with `grid-template-rows: auto auto` — not bare `flex-wrap: wrap` on the header.
+**Applies to:** Headers that reflow at narrow widths.
+**Why:** `flex-wrap: wrap` on a header lets the browser decide which items wrap by available space, producing stranded items — the brand floats beside a 2-of-3 nav row with the leftover item dropped right-aligned below. That reads as a layout bug. Acceptable reflow: the whole nav drops to its own row together, or it collapses behind a trigger (above). Forbidden: brand + partial-nav on row 1 with orphans below. If the header wraps unevenly, refactor the layout — don't patch the orphan with `text-align`.
+
+---
+
+## Sources
+
+- [W3C — WCAG 2.2 1.4.4 Resize Text](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
+- [W3C — WCAG 2.2 1.4.10 Reflow](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html)
+- [MDN — Viewport-percentage lengths (`dvh`, `svh`, `lvh`)](https://developer.mozilla.org/en-US/docs/Web/CSS/length#viewport-percentage_lengths)
+- [MDN — CSS container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries)
+- [MDN — `@media (hover:)` / `(pointer:)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover)
+- [MDN — Responsive images (`srcset`/`sizes`)](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images)
+- [MDN — overflow-x](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x)
+- [MDN — overflow-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)
+- [Utopia — fluid type & space `clamp()` calculator](https://utopia.fyi/type/calculator)
+- [CSS-Tricks — 16px-or-larger text prevents iOS form-zoom](https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/)
+- [CSS-Tricks — Preventing a Grid Blowout](https://css-tricks.com/preventing-a-grid-blowout/)
+- [web.dev — The large, small, and dynamic viewport units](https://web.dev/blog/viewport-units)
+- [Tailwind CSS — Responsive Design](https://tailwindcss.com/docs/responsive-design)

--- a/.claude/agent-rules/ui-ux-designer/rules/spacing.md
+++ b/.claude/agent-rules/ui-ux-designer/rules/spacing.md
@@ -90,49 +90,14 @@ This domain governs the underlying geometry of UI: how elements are sized, how t
 
 ---
 
-## Responsive and breakpoints
-
-### Rule: Design mobile-first — unprefixed for smallest viewport
-**Applies to:** CSS architecture, design tokens.
-**Why:** Progressive enhancement. Mobile constraints are the hardest; widening is additive. Avoids desktop-down design-then-squeeze failure mode.
+## Breakpoints
 
 ### Rule: Use a standard breakpoint set — detect existing tokens and conform
 **Numeric baseline:** Tailwind: sm=640, md=768, lg=1024, xl=1280, 2xl=1536 (px). Material: compact <600, medium 600–839, expanded 840–1199, large 1200–1599, extra-large ≥1600 (dp).
 **Applies to:** Responsive tokens, layout systems.
 **Why:** No universal standard — pick a convention and stay consistent. Mixing two systems in one product produces unexplained gaps.
 
-### Rule: Content must reflow at 320 CSS px without horizontal scroll
-**Numeric baseline:** 320 CSS px minimum. Verify at 320, 375, 414, and 768 CSS px.
-**Applies to:** All layout.
-**Why:** WCAG 1.4.10. Low-vision users zoom or use narrow viewports; fixed-width containers exclude them. The four checkpoints map to the real-world failure modes: 320 (smallest supported), 375 (iPhone SE/mini class), 414 (iPhone Pro Max class), 768 (iPad portrait, common tablet breakpoint).
-
-### Rule: Use `dvh` / `svh` / `lvh` instead of `vh` for full-height layouts
-**Numeric baseline:** `height: 100dvh` (dynamic), `100svh` (small/URL-bar-visible), `100lvh` (large/URL-bar-hidden). Never `100vh` for layouts that must fit the visible viewport.
-**Applies to:** Full-height heroes, full-screen modals, mobile drawers, anything sized to "one screen".
-**Why:** On older mobile browsers, `100vh` is computed against the largest viewport (URL bar hidden), so a `100vh` hero on iOS Safari extends below the visible area when the URL bar is showing — and the size doesn't update when the URL bar retracts, leaving an over-tall section. The dynamic viewport units (`dvh`, `svh`, `lvh`, plus `dvw` etc.) account for browser chrome. Use `dvh` for layout that should track chrome changes; `svh` when you want a guaranteed-fits-on-load size.
-
-### Rule: Avoid `100vw` for widths — use `100%`
-**Applies to:** Full-bleed sections, banners, anything spanning the viewport.
-**Why:** `100vw` includes the scrollbar width on desktop browsers that reserve scrollbar space, causing horizontal overflow equal to the scrollbar (~15px). `width: 100%` with the parent at the viewport width is the safe equivalent.
-
-### Rule: Use `minmax(0, 1fr)` on grid tracks containing images or wide intrinsic content
-**Numeric baseline:** `grid-template-columns: minmax(0, 1fr) ...` (not bare `1fr`) wherever a track may hold an `<img>`, `<picture>`, `<pre>`, or other element with large intrinsic width.
-**Applies to:** CSS Grid track definitions, especially in card grids, galleries, code-block layouts.
-**Why:** A bare `1fr` resolves to `minmax(auto, 1fr)`, where the `auto` minimum is the track's largest intrinsic content size. A 1024px-native image inside a `1fr` track forces a 1024px minimum, pushing the grid past viewport on phones and producing horizontal scroll. `minmax(0, 1fr)` lets the track shrink below content size.
-
----
-
-## Overflow containment
-
-### Rule: Use `overflow-x: clip` (not `hidden`) on `html` and `body` to contain overflow
-**Numeric baseline:** `html, body { overflow-x: clip; }`.
-**Applies to:** Root-level horizontal overflow containment; any element that intentionally overflows its parent (full-bleed sections, oversized headlines, decorative figures past column edges).
-**Why:** `overflow-x: hidden` creates a new scroll container, which breaks `position: sticky` and `position: fixed` on descendants and can trap focus on overflowing inputs. `overflow-x: clip` prevents horizontal scroll without establishing a scroll context, so sticky and fixed positioning continue to work. Older Safari requires both `html` and `body` for the fallback.
-
-### Rule: Apply `overflow-wrap: anywhere; min-width: 0` to display-size text and long-string containers
-**Numeric baseline:** `overflow-wrap: anywhere; min-width: 0` on `h1`, hero/display headings, and any container that may hold URLs, code, or long unbroken strings.
-**Applies to:** Headings ≥ ~32px, slug/URL displays, code blocks inline in prose, anywhere user-supplied strings render.
-**Why:** Default `overflow-wrap: normal` only breaks at whitespace and hyphens, so long compounds ("state-of-the-art"), uppercase brand names, and URLs overflow narrow viewports. `anywhere` lets the engine break mid-word as a last resort. `min-width: 0` is required when the container is a flex/grid item, because flex/grid items default to `min-width: auto` (= intrinsic content size), which can prevent the wrap from taking effect.
+> **Responsive correctness lives in `responsive.md`.** Mobile-first authoring, reflow / no-horizontal-overflow (`minmax(0, 1fr)`, `width: 100%` over `100vw`, `overflow-x: clip`, `overflow-wrap: anywhere`), viewport units (`dvh`/`svh`/`lvh`), fluid `clamp()` scaling, container queries, and input-modality (`hover`/`pointer`) detection all live there. This file owns sizing geometry, grouping, and scales — the touch-target *minimums* below included; `responsive.md` owns cross-viewport / cross-input behavior and references those minimums for coarse-pointer sizing.
 
 ---
 
@@ -152,7 +117,6 @@ This domain governs the underlying geometry of UI: how elements are sized, how t
 
 - [W3C — WCAG 2.2 2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)
 - [W3C — WCAG 2.2 2.5.5 Target Size (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html)
-- [W3C — WCAG 2.2 1.4.10 Reflow](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html)
 - [W3C — WCAG 2.2 2.3.3 Animation from Interactions](https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html)
 - [Apple HIG — Accessibility](https://developer.apple.com/design/human-interface-guidelines/accessibility)
 - [Material Design — Spacing methods](https://m2.material.io/design/layout/spacing-methods.html)
@@ -165,8 +129,4 @@ This domain governs the underlying geometry of UI: how elements are sized, how t
 - [Laws of UX — Fitts's Law](https://lawsofux.com/fittss-law/)
 - [NN/g — Form Design White Space](https://www.nngroup.com/articles/form-design-white-space/)
 - [Emil Kowalski — Agents with Taste](https://emilkowal.ski/ui/agents-with-taste)
-- [MDN — overflow-x](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x)
-- [MDN — overflow-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)
 - [MDN — CSS Logical Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values)
-- [web.dev — The large, small, and dynamic viewport units](https://web.dev/blog/viewport-units)
-- [CSS-Tricks — Preventing a Grid Blowout](https://css-tricks.com/preventing-a-grid-blowout/)

--- a/.claude/agent-rules/ui-ux-designer/rules/typography.md
+++ b/.claude/agent-rules/ui-ux-designer/rules/typography.md
@@ -93,6 +93,10 @@ This domain governs how text is sized, spaced, weighted, and rendered — contra
 **Applies to:** Hero h1, marketing landing headlines, any oversized single-statement block.
 **Why:** Display sizes are tuned for short, dense statements. Short statements can take the full display size; longer statements step down. Headlines beyond roughly 90 characters are usually wrong as display type and should be rewritten or treated as deck/subhead. The fix is almost always shorter copy, not bigger type.
 
+### Rule: Brand wordmarks must not break mid-word
+**Applies to:** Brand-name display text set at hero size (the wordmark). Distinct from generic display text (marketing line, section title), where `overflow-wrap: anywhere` remains the correct overflow mitigation — see `responsive.md`.
+**Why:** A wordmark broken across two lines — "BRANDNA / ME" — reads as a layout bug and loses brand recognizability, so `word-break: break-word` / `overflow-wrap: anywhere` are NOT acceptable mitigations for `clamp()` overflow on a wordmark. Correct fixes: (a) lower the `clamp()` max until the word fits at 375px even at its heaviest weight; (b) auto-shrink with `font-size: min(<fluid-target>, 100vw / <character-count>)`; (c) commit to a deliberately stacked-words treatment that breaks at hand-set positions.
+
 ---
 
 ## Caps, tracking, micro-typography

--- a/docs/agents/ui-ux-designer/ui-ux-designer.md
+++ b/docs/agents/ui-ux-designer/ui-ux-designer.md
@@ -46,11 +46,12 @@ These apply to every UI surface you produce, including HTML previews. They are n
 
 For deeper taste decisions, READ the relevant rules file. Do NOT read these proactively — read only when the task actually requires that domain. Avoid burning context on rules you don't need.
 
-- **Motion, animation, transitions, easing, durations** → `docs/agents/ui-ux-designer/rules/motion.md`
-- **Typography, text rendering, font scales, line-height, measure** → `docs/agents/ui-ux-designer/rules/typography.md`
-- **Color, palette construction, contrast, dark mode** → `docs/agents/ui-ux-designer/rules/color.md`
-- **Spacing, layout, grid, breakpoints, whitespace** → `docs/agents/ui-ux-designer/rules/spacing.md`
-- **Component patterns** (buttons, forms, modals, toasts, loading/empty/error states, tables, nav, tooltips, popovers) → `docs/agents/ui-ux-designer/rules/components.md`
+- **Motion, animation, transitions, easing, durations** → `.claude/agent-rules/ui-ux-designer/rules/motion.md`
+- **Typography, text rendering, font scales, line-height, measure** → `.claude/agent-rules/ui-ux-designer/rules/typography.md`
+- **Color, palette construction, contrast, dark mode** → `.claude/agent-rules/ui-ux-designer/rules/color.md`
+- **Spacing, sizing, grid, grouping, touch-target minimums, whitespace, z-index** → `.claude/agent-rules/ui-ux-designer/rules/spacing.md`
+- **Responsive correctness** (mobile-first, reflow / horizontal-overflow, viewport units `dvh`/`svh`, fluid `clamp()` scaling, container queries, touch-vs-pointer input, responsive images, mobile nav reflow) → `.claude/agent-rules/ui-ux-designer/rules/responsive.md`
+- **Component patterns** (buttons, forms, modals, toasts, loading/empty/error states, tables, media/images, nav, tooltips, popovers) → `.claude/agent-rules/ui-ux-designer/rules/components.md`
 
 Each rule file ends with a `## Sources` section citing the authoritative docs for that domain (WCAG, Kowalski, Butterick, Bringhurst, NN/g, Apple HIG, Material, Radix, etc.).
 


### PR DESCRIPTION
Applies agent-toolkit migration 2026-05-28 (responsive.md adoption + ui-ux-designer rule additions). Scoped to the ui-ux-designer rule library + entry-doc routing patch (which also repairs stale `docs/agents/.../rules/` paths to `.claude/agent-rules/.../rules/`).

See agent-toolkit `migrations/2026-05-28-responsive-rules.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)